### PR TITLE
fix(ci): resolve zizmor security findings in workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "09:30"
       timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
     pull-request-branch-name:
       separator: "/"
     commit-message:
@@ -20,6 +22,8 @@ updates:
       day: "monday"
       time: "09:45"
       timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
     pull-request-branch-name:
       separator: "/"
     commit-message:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,15 +11,22 @@ env:
   IMAGE_NAME: json
   MAJOR_VERSION: 11
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v6
-      
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           build-args: MAJOR_VERSION=${{ env.MAJOR_VERSION }}
@@ -36,38 +43,44 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           flavor: latest=true
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}, ghcr.io/chorrell/${{ env.IMAGE_NAME }}
           tags: ${{ env.MAJOR_VERSION }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Fixes all findings reported by zizmor v1.25.2:

**`.github/workflows/docker-publish.yml`**
- **unpinned-uses** (9 high): Pin all action references to commit SHAs with full version tag comments
- **excessive-permissions** (3 medium): Add `permissions: {}` at workflow level; add explicit `contents: read` per job and `packages: write` for the push job
- **artipacked** (2 low): Add `persist-credentials: false` to both `actions/checkout` steps

**`.github/dependabot.yml`**
- **dependabot-cooldown** (2 medium): Add `cooldown: default-days: 7` to both `github-actions` and `docker` ecosystems