### PR TITLE
ci: add concurrency group to cancel superseded runs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,10 @@ on:
 
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   IMAGE_NAME: json
   MAJOR_VERSION: 11


### PR DESCRIPTION
Adds a workflow-level concurrency group so that pushing a second commit to a PR cancels the previous run. Pushes to `main` are never cancelled (releases should always complete).

- PR runs: `cancel-in-progress: true`
- `main` pushes: `cancel-in-progress: false`