### PR TITLE
ci: add timeout-minutes to prevent runaway jobs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,7 @@ permissions: {}
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     permissions:
       contents: read
@@ -41,6 +42,7 @@ jobs:
     needs: test
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'push'
 
     permissions:


### PR DESCRIPTION
Caps both jobs at 15 minutes. GitHub's default timeout is 6 hours; a stuck build would otherwise consume the full runner quota before failing.