### PR TITLE
ci: use GITHUB_TOKEN instead of CR_PAT for GHCR login

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,8 +76,8 @@ jobs:
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0


### PR DESCRIPTION
The `push` job already has `permissions: packages: write`, so the built-in `GITHUB_TOKEN` is sufficient for authenticating with `ghcr.io`. This removes the need to create, rotate, or store a personal access token (`CR_PAT`) as a repo secret.

The `CR_PAT` secret can be deleted from the repository after this is merged.