### PR TITLE
ci: add GHA layer cache to push job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -90,3 +90,5 @@ jobs:
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds `cache-from: type=gha` and `cache-to: type=gha,mode=max` to the `Build and push` step. The `push` job already has `docker/setup-buildx-action` so no additional setup is required.

On repeat pushes to `main`, unchanged layers will be restored from the GHA cache instead of rebuilt from scratch, reducing build time significantly.

Note: per-platform scoped caching for the `test` job is introduced separately alongside the arm64 matrix (PR #TODO).