### PR TITLE
ci: add arm64 matrix to test job with per-platform GHA cache

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,21 +20,35 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
       - name: Build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           build-args: MAJOR_VERSION=${{ env.MAJOR_VERSION }}
           load: true
           tags: ${{ env.IMAGE_NAME }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
       - name: Test
-        run: cat test.json | docker run -i --rm ${{ env.IMAGE_NAME }} -ag name value
+        run: cat test.json | docker run -i --rm --platform ${{ matrix.platform }} ${{ env.IMAGE_NAME }} -ag name value
 
   push:
     # Ensure test job passes before pushing image.


### PR DESCRIPTION
Expands the `test` job to run in parallel for both `linux/amd64` and `linux/arm64` using a matrix strategy. QEMU and Buildx are added to support cross-architecture builds on the amd64 runner.

- `fail-fast: false` ensures both platforms are always reported even if one fails
- GHA cache is scoped per-platform (`scope=linux/amd64` / `scope=linux/arm64`) so each platform maintains its own cache entry
- The `Test` step passes `--platform` to `docker run` to exercise the correct architecture via QEMU

Note: if merged alongside #94, the push job's unscoped cache and the test job's scoped cache will coexist without conflict.