### PR TITLE
ci: add GitHub native build attestations for Docker Hub and GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,6 +66,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -100,6 +102,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -112,3 +115,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Attest Docker Hub image
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: index.docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest GHCR image
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/chorrell/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Uses `actions/attest-build-provenance` (SHA-pinned to v4.1.0) to publish GitHub native SLSA provenance attestations alongside the pushed image, in addition to the existing buildx `provenance: mode=max` and `sbom: true`.

Changes:
- Adds `id-token: write` and `attestations: write` to the `push` job permissions
- Adds `id: build` to the `Build and push` step to capture the image digest
- Two attestation steps: one for Docker Hub (`index.docker.io/...`) and one for GHCR (`ghcr.io/...`)

Attestations are verifiable with `gh attestation verify`.