### PR TITLE
chore: add hadolint pre-commit hook and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,18 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
+    pull-request-branch-name:
+      separator: "/"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,8 @@ repos:
     rev: v1.25.2
     hooks:
       - id: zizmor
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker


### PR DESCRIPTION
## Changes

- Add **hadolint-docker** (v2.14.0) pre-commit hook for Dockerfile linting
- Add **pre-commit** ecosystem to dependabot for automatic hook version updates

Hadolint ran cleanly on the existing Dockerfile with no issues found.