### PR TITLE
chore: switch pre-commit dependabot updates to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,7 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "daily"
-      timezone: "America/Toronto"
+      interval: "weekly"
     cooldown:
       default-days: 7
     pull-request-branch-name:


### PR DESCRIPTION
Changes the `pre-commit` package-ecosystem schedule in `.github/dependabot.yml` from daily to weekly, and sets a 7-day cooldown (`default-days: 7`).